### PR TITLE
Use strict date format checking during imports

### DIFF
--- a/ember/app/controllers/importer.js
+++ b/ember/app/controllers/importer.js
@@ -44,7 +44,7 @@ export default Ember.Controller.extend({
           continue;  
         }
         
-        entryDate = moment(line);
+        entryDate = moment(line, 'YYYY-MM-DD', true);
         if (entryDate.isValid()) {
           if (currentEntry) {
             currentEntry.text = $.trim(currentEntry.text);


### PR DESCRIPTION
Prevent false positives by enforcing YYYY-MM-DD (used by most web journals)

The last true enables a very strict parsing mode.

DayJot inputs each line into moment() to see if the line marks a new entry. False
positives were causing absurd entry breaks into years like "1981".

moment() is very liberal and browser-dependent without strictness enabled. For
example, moment("This year, I took CS 101.").isValid() returns true in Chromium 39.

---

I was getting some strange errors when attempting to import my OhLife journal from Chromium:

![import errors with weird dates](https://cloud.githubusercontent.com/assets/217986/5562681/1a465b02-8df6-11e4-8bae-d7351d7e3b99.png)

After looking into it, I discovered that the importer was treating certain lines that contained things like "CS 101" as dates.

It turns out the moment.js is very liberal with only one argument, and it uses the browser's Date.parse() as a last resort. Chrome tries to date-ify any string, while Firefox tends to return NaN more often.

moment.js has a [strict mode](http://momentjs.com/docs/#/parsing/string-format/) that should work. DayJot, OhLife, and DailyDiary all export in YYYY-MM-DD format (although DailyDiary also includes a time after the newline).
