### PR TITLE
Fix import skipping last entry if there's a newline

### DIFF
--- a/ember/app/controllers/importer.js
+++ b/ember/app/controllers/importer.js
@@ -60,11 +60,13 @@ export default Ember.Controller.extend({
             currentEntry.text = currentEntry.text + line + "\n";
           }
         }
+      }
 
-        if (typeof lines[i+1] === 'undefined' && currentEntry) {
-          currentEntry.text = $.trim(currentEntry.text);
-          entries.push(currentEntry);
-        }
+      // ran out of lines, need to handle the last entry
+      // this must happen even if the last line was a newline
+      if (currentEntry) {
+        currentEntry.text = $.trim(currentEntry.text);
+        entries.push(currentEntry);
       }
 
       this.set('entryCount', entries.length);


### PR DESCRIPTION
The importer was continue-ing the loop if the line is a newline,
even if it was the last line. This meant that the code handling
the final entry was skipped.

Remove a now unnecessary check to see if the next line is
undefined.
