### PR TITLE
Fix time being imported as part of entry from DailyDiary

### DIFF
--- a/ember/app/controllers/importer.js
+++ b/ember/app/controllers/importer.js
@@ -55,6 +55,17 @@ export default Ember.Controller.extend({
             date: entryDate.utc().toDate(),
             text: ""
           };
+
+          // DailyDiary text exports are formatted as such:
+          // 2015-01-01
+          // 22:00
+          //
+          // Rest of entry...
+          //
+          // So if the next line is a time, skip it to support DailyDiary exports.
+          if (moment(lines[i+1], 'HH:mm', true).isValid()) {
+            i++;
+          }
         } else {
           if (currentEntry) {
             currentEntry.text = currentEntry.text + line + "\n";


### PR DESCRIPTION
Right now if you import text from DailyDiary, the time of the entry is put at the top of every entry:

![time at the top of every entry](https://cloud.githubusercontent.com/assets/217986/5563103/a7e22212-8e1d-11e4-8891-85f93e137ab1.png)

I thought this was fairly ugly and out-of-place. It happens because DailyDiary includes the entry's time right under the date, so I patched the importer to skip the time.

Though I guess some users might want to keep the time? Up to you I guess.

---

DailyDiary text exports contain the date and the time. The importer
only expected the date, so it would place the entry's time at the
beginning of the entry.

Skip the time (which afaik DayJot does not use) so that these
entries are cleaner.
